### PR TITLE
fix: Always pass `errorIconAriaLabel` to FormField

### DIFF
--- a/src/pages/form/components/distribution-panel.jsx
+++ b/src/pages/form/components/distribution-panel.jsx
@@ -119,6 +119,7 @@ export default function DistributionPanel({ updateTools, updateDirty = noop, rea
           }
           description="Enter the name of the object that you want CloudFront to return when a viewer request points to your root URL."
           errorText={getErrorText('You must specify a root object.')}
+          i18nStrings={{ errorIconAriaLabel: 'Error' }}
         >
           <Input
             value={distributionPanelData.cloudFrontRootObject}
@@ -144,6 +145,7 @@ export default function DistributionPanel({ updateTools, updateDirty = noop, rea
           constraintText="Specify up to 100 CNAMEs separated with commas, or put each on a new line."
           stretch={true}
           errorText={getErrorText('You must specify at least one alternative domain name.')}
+          i18nStrings={{ errorIconAriaLabel: 'Error' }}
         >
           <Textarea
             placeholder={'www.one.example.com\nwww.two.example.com'}
@@ -155,6 +157,7 @@ export default function DistributionPanel({ updateTools, updateDirty = noop, rea
           label="S3 bucket for logs"
           description="The Amazon S3 bucket that you want CloudFront to store your access logs in."
           errorText={getErrorText('You must specify a S3 bucket.')}
+          i18nStrings={{ errorIconAriaLabel: 'Error' }}
         >
           <Select
             {...contentOriginsHandlers}
@@ -187,6 +190,7 @@ export default function DistributionPanel({ updateTools, updateDirty = noop, rea
               className="date-time-container"
               errorText={getErrorText('Invalid date format.')}
               constraintText={'Use YYYY/MM/DD format.'}
+              i18nStrings={{ errorIconAriaLabel: 'Error' }}
             >
               <DatePicker
                 ariaLabelledby="certificate-expiry-label"
@@ -207,6 +211,7 @@ export default function DistributionPanel({ updateTools, updateDirty = noop, rea
               constraintText="Use 24-hour format."
               className="date-time-container"
               errorText={getErrorText('Invalid time format.')}
+              i18nStrings={{ errorIconAriaLabel: 'Error' }}
             >
               <TimeInput
                 ariaLabelledby="certificate-expiry-label"

--- a/src/pages/form/components/origin-panel.jsx
+++ b/src/pages/form/components/origin-panel.jsx
@@ -35,6 +35,7 @@ export default function OriginPanel({ updateTools, readOnlyWithErrors = false })
           }
           description="The Amazon S3 bucket or web server that you want CloudFront to get your web content from."
           errorText={getErrorText('You must specify a content origin.')}
+          i18nStrings={{ errorIconAriaLabel: 'Error' }}
         >
           <Multiselect
             {...contentOriginsHandlers}
@@ -70,6 +71,7 @@ export default function OriginPanel({ updateTools, readOnlyWithErrors = false })
           }
           description="The directory in your Amazon S3 bucket or your custom origin."
           errorText={getErrorText('You must specify a path to content.')}
+          i18nStrings={{ errorIconAriaLabel: 'Error' }}
         >
           <Input
             placeholder="/images"
@@ -89,6 +91,7 @@ export default function OriginPanel({ updateTools, readOnlyWithErrors = false })
           }
           description="This value lets you distinguish multiple origins in the same distribution from one another."
           errorText={getErrorText('You must specify a origin ID.')}
+          i18nStrings={{ errorIconAriaLabel: 'Error' }}
         >
           <Input
             ariaRequired={true}

--- a/src/pages/s3/read-from-s3.index.jsx
+++ b/src/pages/s3/read-from-s3.index.jsx
@@ -95,6 +95,7 @@ class S3ResourceSelectorContainer extends React.Component {
         constraintText="Format: s3://bucket/prefix/object. For objects in a bucket with versioning activated, you can choose the most recent or a previous version of the object."
         errorText={errorText}
         stretch={true}
+        i18nStrings={{ errorIconAriaLabel: 'Error' }}
       >
         <S3ResourceSelector {...s3ResourceSelectorProps} />
       </FormField>

--- a/src/pages/s3/write-to-s3.index.jsx
+++ b/src/pages/s3/write-to-s3.index.jsx
@@ -102,6 +102,7 @@ class S3ResourceSelectorContainer extends React.Component {
         constraintText="Format: s3://bucket/prefix."
         errorText={errorText}
         stretch={true}
+        i18nStrings={{ errorIconAriaLabel: 'Error' }}
       >
         <S3ResourceSelector {...s3ResourceSelectorProps} />
       </FormField>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Always pass `errorIconAriaLabel` to FormField

CR-76086826

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
