### PR TITLE
Update icons for density settings

### DIFF
--- a/src/pages/dashboard/density-switch-images/comfortable-visual-refresh.jsx
+++ b/src/pages/dashboard/density-switch-images/comfortable-visual-refresh.jsx
@@ -1,28 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import React from 'react';
-import { getClassName, TableRows, WindowPath, TopNavigation, ColumnHeaders } from './common';
+import { getClassName, TableRows, TableRow, WindowPath, TopNavigation } from './common';
 
 const comfortableImage = (
   <svg viewBox="0 0 230 107" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden={true}>
     <WindowPath />
     <TopNavigation />
     <g className="awsui-context-content-header">
-      <path className={getClassName('header')} d="M24 8.00006H211V33.0001H24V8.00006Z" />
+      <path className={getClassName('header')} d="M24 8.00006H211V28.0001H24V8.00006Z" />
       <g className={getClassName('default')}>
-        <circle cx="29" cy="15.5001" r="2.5" className={getClassName('disabled')} />
-        <path d="M47 14.0001H77.1484V17.0001H47V14.0001Z" />
-        <path d="M121 15.5C121 13.567 122.567 12 124.5 12H137.86C139.793 12 141.36 13.567 141.36 15.5V15.5C141.36 17.433 139.793 19 137.86 19H124.5C122.567 19 121 17.433 121 15.5V15.5Z" />
-        <path d="M145 15.5C145 13.567 146.567 12 148.5 12H161.86C163.793 12 165.36 13.567 165.36 15.5V15.5C165.36 17.433 163.793 19 161.86 19H148.5C146.567 19 145 17.433 145 15.5V15.5Z" />
+        <circle cx="29" cy="17.5001" r="2.5" className={getClassName('disabled')} />
+        <path d="M47 16.0001H77.1484V19.0001H47V16.0001Z" />
+        <path d="M121 17.5C121 15.567 122.567 14 124.5 14H137.86C139.793 14 141.36 15.567 141.36 17.5V17.5C141.36 19.433 139.793 21 137.86 21H124.5C122.567 21 121 19.433 121 17.5V17.5Z" />
+        <path d="M145 17.5C145 15.567 146.567 14 148.5 14H161.86C163.793 14 165.36 15.567 165.36 17.5V17.5C165.36 19.433 163.793 21 161.86 21H148.5C146.567 21 145 19.433 145 17.5V17.5Z" />
         <path
-          d="M168 15.5C168 13.567 169.567 12 171.5 12H184.86C186.793 12 188.36 13.567 188.36 15.5V15.5C188.36 17.433 186.793 19 184.86 19H171.5C169.567 19 168 17.433 168 15.5V15.5Z"
+          d="M168 17.5C168 15.567 169.567 14 171.5 14H184.86C186.793 14 188.36 15.567 188.36 17.5V17.5C188.36 19.433 186.793 21 184.86 21H171.5C169.567 21 168 19.433 168 17.5V17.5Z"
           className={getClassName('primary')}
         />
-        <circle cx="206.5" cy="15.5001" r="2.5" className={getClassName('disabled')} />
+        <circle cx="206.5" cy="17.5001" r="2.5" className={getClassName('disabled')} />
       </g>
-      <ColumnHeaders offset={25} />
     </g>
-    <TableRows offsetTop={37} rows={6} />
+    <TableRow offset={32} isHeader={true} />
+
+    <TableRows offsetTop={45} rows={5} />
   </svg>
 );
 

--- a/src/pages/dashboard/density-switch-images/common.jsx
+++ b/src/pages/dashboard/density-switch-images/common.jsx
@@ -4,14 +4,17 @@ import React from 'react';
 
 export const getClassName = element => `density-switch-${element}`;
 
-const TableRow = ({ offset, separator = true, compact = false }) => {
+export const TableRow = ({ offset, separator = true, compact = false, isHeader = false }) => {
   const offsetTop = 0.4482;
   const offsetBottom = 3.4482;
   const separatorDistance = compact ? 7 : 8;
   return (
-    <g transform={`translate(0, ${offset})`} className={getClassName('disabled')}>
+    <g transform={`translate(0, ${offset})`} className={getClassName(isHeader ? 'column-header' : 'disabled')}>
       <path d={`M53 ${offsetTop}H56V${offsetBottom}H53V${offsetTop}Z`} />
-      <path d={`M61 ${offsetTop}H85V${offsetBottom}H61V${offsetTop}Z`} className={getClassName('secondary')} />
+      <path
+        d={`M61 ${offsetTop}H85V${offsetBottom}H61V${offsetTop}Z`}
+        className={!isHeader ? getClassName('secondary') : undefined}
+      />
       <path d={`M138 ${offsetTop}H118V${offsetBottom}H138V${offsetTop}Z`} />
       <path d={`M185 ${offsetTop}H141V${offsetBottom}H185V${offsetTop}Z`} />
       {separator && (
@@ -22,7 +25,7 @@ const TableRow = ({ offset, separator = true, compact = false }) => {
 };
 
 export const TableRows = ({ offsetTop, rows, compact = false }) => {
-  const distance = compact ? 10 : 12;
+  const distance = compact ? 10 : 13;
   return (
     <g>
       {[...Array(rows)].map((_, index) => (
@@ -42,14 +45,5 @@ export const WindowPath = () => (
 export const TopNavigation = () => (
   <g className="awsui-context-top-navigation">
     <rect x="24" y="2" width="187" height="6" className={getClassName('top-navigation')} />
-  </g>
-);
-
-export const ColumnHeaders = ({ offset }) => (
-  <g transform={`translate(0, ${offset})`} className={getClassName('default')}>
-    <path d="M138 0.4483H118V3.4483H138V0.4483Z" />
-    <path d="M185 0.4483H141V3.4483H185V0.4483Z" />
-    <path d="M61 0.4483H85V3.4483H61V0.4483Z" />
-    <path d="M53 0.4483H56V3.4483H53V0.4483Z" />
   </g>
 );

--- a/src/pages/dashboard/density-switch-images/compact-visual-refresh.jsx
+++ b/src/pages/dashboard/density-switch-images/compact-visual-refresh.jsx
@@ -1,28 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import React from 'react';
-import { getClassName, TableRows, WindowPath, TopNavigation, ColumnHeaders } from './common';
+import { getClassName, TableRows, TableRow, WindowPath, TopNavigation } from './common';
 
 const compactImage = (
   <svg viewBox="0 0 230 107" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden={true}>
     <WindowPath />
     <TopNavigation />
     <g className="awsui-context-content-header">
-      <path className={getClassName('header')} d="M24 8.00006H211V26.0001H24V8.00006Z" />
+      <path className={getClassName('header')} d="M24 8.00006H211V24.0001H24V8.00006Z" />
       <g className={getClassName('default')}>
-        <circle cx="29" cy="14.5001" r="2.5" className={getClassName('disabled')} />
-        <path d="M47 13.0001H77.1484V16.0001H47V13.0001Z" />
-        <path d="M121 14C121 12.8954 121.895 12 123 12H139.36C140.465 12 141.36 12.8954 141.36 14V14C141.36 15.1046 140.465 16 139.36 16H123C121.895 16 121 15.1046 121 14V14Z" />
-        <path d="M145 14C145 12.8954 145.895 12 147 12H163.36C164.465 12 165.36 12.8954 165.36 14V14C165.36 15.1046 164.465 16 163.36 16H147C145.895 16 145 15.1046 145 14V14Z" />
+        <circle cx="29" cy="15.5001" r="2.5" className={getClassName('disabled')} />
+        <path d="M47 14H77.1484V17H47V14Z" />
+        <path d="M121 15C121 13.8954 121.895 13 123 13H139.36C140.465 13 141.36 13.8954 141.36 15V15C141.36 16.1046 140.465 17 139.36 17H123C121.895 17 121 16.1046 121 15V15Z" />
+        <path d="M145 15C145 13.8954 145.895 13 147 13H163.36C164.465 13 165.36 13.8954 165.36 15V15C165.36 16.1046 164.465 17 163.36 17H147C145.895 17 145 16.1046 145 15V15Z" />
         <path
-          d="M168 14C168 12.8954 168.895 12 170 12H186.36C187.465 12 188.36 12.8954 188.36 14V14C188.36 15.1046 187.465 16 186.36 16H170C168.895 16 168 15.1046 168 14V14Z"
+          d="M168 15C168 13.8954 168.895 13 170 13H186.36C187.465 13 188.36 13.8954 188.36 15V15C188.36 16.1046 187.465 17 186.36 17H170C168.895 17 168 16.1046 168 15V15Z"
           className={getClassName('primary')}
         />
-        <circle cx="206.5" cy="14.5001" r="2.5" className={getClassName('disabled')} />
-        <ColumnHeaders offset={20} />
+        <circle cx="206.5" cy="15.5001" r="2.5" className={getClassName('disabled')} />
       </g>
     </g>
-    <TableRows offsetTop={29} compact={true} rows={8} />
+    <TableRow offset={27} compact={true} isHeader={true} />
+    <TableRows offsetTop={37} compact={true} rows={7} />
   </svg>
 );
 

--- a/src/styles/density-switch-images.scss
+++ b/src/styles/density-switch-images.scss
@@ -22,10 +22,13 @@
   &-disabled {
     fill: cs.$color-background-control-disabled;
   }
+  &-column-header {
+    fill: cs.$color-text-input-disabled;
+  }
   &-secondary {
     fill: cs.$color-text-body-secondary;
   }
   &-separator {
-    stroke: cs.$color-border-button-primary-disabled;
+    stroke: cs.$color-border-divider-default;
   }
 }


### PR DESCRIPTION
*Description of changes:*

This updates the preview SVGs that are shown in the "Density settings" dialog of the Dashboard demo. The table has a new header style, which needs to be reflected in these previews.

Compare also the `src/split-panel/icons` folder in [the components PR](https://github.com/cloudscape-design/components/pull/407/files), which does a similar change for the choice of split panel position, as well as CR-78870464.

------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
