### PR TITLE
Switch side navigation to uncontrolled state

### DIFF
--- a/src/pages/form/form-unsaved-changes.index.jsx
+++ b/src/pages/form/form-unsaved-changes.index.jsx
@@ -22,7 +22,6 @@ import '../../styles/form.scss';
 function App() {
   const [toolsIndex, setToolsIndex] = useState(0);
   const [toolsOpen, setToolsOpen] = useState(false);
-  const [navigationOpen, setNavigationOpen] = useState(true);
   const [dirty, setDirty] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
   const appLayout = useRef();
@@ -121,8 +120,6 @@ function App() {
       tools={ToolsContent[toolsIndex]}
       toolsOpen={toolsOpen}
       onToolsChange={({ detail }) => setToolsOpen(detail.open)}
-      navigationOpen={navigationOpen}
-      onNavigationChange={({ detail }) => setNavigationOpen(detail.open)}
       ariaLabels={appLayoutLabels}
       notifications={<Notifications />}
     />

--- a/src/pages/non-console/non-console.index.jsx
+++ b/src/pages/non-console/non-console.index.jsx
@@ -165,7 +165,6 @@ const DemoHeaderPortal = ({ children }) => {
 };
 
 function App() {
-  const [navigationOpen, setNavigationOpen] = useState(true);
   const [searchValue, setSearchValue] = useState('');
   return (
     <>
@@ -210,12 +209,10 @@ function App() {
         toolsHide
         headerSelector="#header"
         ariaLabels={{ navigationClose: 'close' }}
-        navigationOpen={navigationOpen}
         navigation={<SideNavigation activeHref="#/pages" items={navItems} />}
         breadcrumbs={<BreadcrumbGroup items={breadcrumbs} expandAriaLabel="Show path" ariaLabel="Breadcrumbs" />}
         contentType="table"
         content={<Content />}
-        onNavigationChange={({ detail }) => setNavigationOpen(detail.open)}
         notifications={<Notifications />}
       />
     </>


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This removes the explicit state handling of the side navigation and replaces it with the built-in state handling. This makes the side navigation automatically disappear on narrow viewports (such as mobile screens).

See also CR-78735274.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
