### PR TITLE
Use headerText instead of header in Expandablesection

### DIFF
--- a/src/pages/edit/edit.index.jsx
+++ b/src/pages/edit/edit.index.jsx
@@ -42,7 +42,7 @@ const DistributionsFooter = props => {
   const [loggingEnabled, setLoggingEnabled] = useState(false);
   const [ipv6Enabled, setIpv6Enabled] = useState(false);
   return (
-    <ExpandableSection header="Additional settings" variant="footer">
+    <ExpandableSection headerText="Additional settings" variant="footer">
       <SpaceBetween size="l">
         <FormField
           label="Supported HTTP versions"

--- a/src/pages/form/components/cache-behavior-footer.jsx
+++ b/src/pages/form/components/cache-behavior-footer.jsx
@@ -31,7 +31,7 @@ export default function CacheBehaviorFooter({ readOnlyWithErrors = false }) {
   };
 
   return (
-    <ExpandableSection header="Additional settings" variant="footer">
+    <ExpandableSection headerText="Additional settings" variant="footer">
       <SpaceBetween size="l">
         <div>
           <Box variant="awsui-key-label">Path pattern</Box>

--- a/src/pages/form/components/distribution-panel.jsx
+++ b/src/pages/form/components/distribution-panel.jsx
@@ -21,7 +21,7 @@ import { SSL_CERTIFICATE_OPTIONS, SUPPORTED_HTTP_VERSIONS_OPTIONS } from '../for
 
 function DistributionsFooter({ state, onChange }) {
   return (
-    <ExpandableSection header="Additional settings" variant="footer">
+    <ExpandableSection headerText="Additional settings" variant="footer">
       <SpaceBetween size="l">
         <FormField
           label="Supported HTTP versions"

--- a/src/pages/wizard/stepComponents/step2.jsx
+++ b/src/pages/wizard/stepComponents/step2.jsx
@@ -43,7 +43,7 @@ const InstanceOptions = ({
     <Container
       header={<Header variant="h2">Instance options</Header>}
       footer={
-        <ExpandableSection header="Additional options" variant="footer">
+        <ExpandableSection headerText="Additional options" variant="footer">
           <SpaceBetween size="l">
             <FormField
               label={

--- a/src/pages/wizard/stepComponents/step3.jsx
+++ b/src/pages/wizard/stepComponents/step3.jsx
@@ -149,7 +149,7 @@ const MaintenanceAndMonitoring = ({ failover, backtrack, upgrades, backup, monit
     <Container
       header={<Header variant="h2">Maintenance and monitoring</Header>}
       footer={
-        <ExpandableSection header="Additional settings" variant="footer">
+        <ExpandableSection headerText="Additional settings" variant="footer">
           <SpaceBetween size="l">
             <FormField
               label="Failover priority"

--- a/src/pages/wizard/stepComponents/step4.jsx
+++ b/src/pages/wizard/stepComponents/step4.jsx
@@ -79,7 +79,7 @@ const Review = ({ info: { engine, details, advanced }, setActiveStepIndex }) => 
             <Container
               header={<Header variant="h2">Instance options</Header>}
               footer={
-                <ExpandableSection header="Additional options" variant="footer">
+                <ExpandableSection headerText="Additional options" variant="footer">
                   <ColumnLayout columns={2} variant="text-grid">
                     <div>
                       <Box variant="awsui-key-label">Time zone</Box>
@@ -188,7 +188,7 @@ const Review = ({ info: { engine, details, advanced }, setActiveStepIndex }) => 
             <Container
               header={<Header variant="h2">Maintenance and monitoring</Header>}
               footer={
-                <ExpandableSection header="Additional options" variant="footer">
+                <ExpandableSection headerText="Additional options" variant="footer">
                   <ColumnLayout columns={2} variant="text-grid">
                     <div>
                       <Box variant="awsui-key-label">Failover priority</Box>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use `headerText` to replace `header` to align with API change from https://github.com/cloudscape-design/components/pull/473

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
