### PR TITLE
feat: Add arialabels to tutorial panel download and read more links

### DIFF
--- a/src/pages/onboarding/i18n.js
+++ b/src/pages/onboarding/i18n.js
@@ -19,6 +19,8 @@ export const tutorialPanelI18nStrings = {
   stepTitle: (stepIndex, stepTitle) => `Step ${stepIndex + 1}: ${stepTitle}`,
   labelTotalSteps: totalStepCount => `Total steps: ${totalStepCount}`,
   labelLearnMoreExternalIcon: 'Opens in a new tab',
+  labelTutorialListDownloadLink: 'Download PDF version of this tutorial',
+  labelLearnMoreLink: 'Learn more about transcribe audio (opens new tab)',
 };
 
 export const overlayI18nStrings = {


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Add `labelTutorialListDownloadLink` and `labelLearnMoreLink props`, to allow aria-label on download link and learn more link. The labels were recently added by PR https://github.com/cloudscape-design/components/pull/534

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
