### PR TITLE
chore: Update check-package-lock script to be compatible with npm v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,120 +1864,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@cloudscape-design/browser-test-tools": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.14.tgz",
-      "integrity": "sha512-IAu9/88bq8t0Lh+70vHpR1tz1IH88v2Tlwa11R0tqS0B5mh9hLrIoZMqisE4v3Ir5rn+QGxN3t5mSXfZd0wzPw==",
-      "dev": true,
-      "dependencies": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1233.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.25.2"
-      }
-    },
-    "node_modules/@cloudscape-design/collection-hooks": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.16.tgz",
-      "integrity": "sha512-AAgyi3y34yTQ3TsFTyOQWUYX1ooelCil9e+OdFL5AAuzwas3Pv/WBYOu2rM5l3Lmw+bgt6EPf8rOJEXpbVXA5g==",
-      "dev": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@cloudscape-design/components": {
-      "version": "3.0.149",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.149.tgz",
-      "integrity": "sha512-ljM7Zrkms8Le8RiwtUwK6W5X2RWNZ2y6Mzre+bsV0WUwTq7zVqwMcC15EaZjb2LfmidMfkf4baC6KmY/iZ4PyQ==",
-      "dev": true,
-      "dependencies": {
-        "@cloudscape-design/collection-hooks": "^1.0.0",
-        "@cloudscape-design/test-utils-core": "^1.0.0",
-        "@cloudscape-design/theming-runtime": "^1.0.0",
-        "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.4.13",
-        "balanced-match": "^1.0.2",
-        "clsx": "^1.1.0",
-        "d3-shape": "^1.3.7",
-        "date-fns": "^2.25.0",
-        "mnth": "^2.0.0",
-        "react-focus-lock": "~2.8.1",
-        "react-keyed-flatten-children": "^1.3.0",
-        "react-resizable": "^1.11.1",
-        "react-transition-group": "^4.4.2",
-        "react-virtual": "^2.8.2",
-        "tslib": "^2.4.0",
-        "weekstart": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
-    },
-    "node_modules/@cloudscape-design/components/node_modules/react-resizable": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.11.1.tgz",
-      "integrity": "sha512-S70gbLaAYqjuAd49utRHibtHLrHXInh7GuOR+6OO6RO6uleQfuBnWmZjRABfqNEx3C3Z6VPLg0/0uOYFrkfu9Q==",
-      "dev": true,
-      "dependencies": {
-        "prop-types": "15.x",
-        "react-draggable": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "0.14.x || 15.x || 16.x || 17.x",
-        "react-dom": "0.14.x || 15.x || 16.x || 17.x"
-      }
-    },
-    "node_modules/@cloudscape-design/components/node_modules/react-virtual": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
-      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/tannerlinsley"
-      ],
-      "dependencies": {
-        "@reach/observe-rect": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.3 || ^17.0.0"
-      }
-    },
-    "node_modules/@cloudscape-design/design-tokens": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/design-tokens/-/design-tokens-3.0.6.tgz",
-      "integrity": "sha512-fsJcv1EbybKpRJSke5Pw5wkr4zrsfqVdLKNjRbfxVhEVrJUjE49LOHm1y+CHjScDdEZ51/4AgUB/XEWAfI47mg==",
-      "dev": true
-    },
-    "node_modules/@cloudscape-design/global-styles": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.6.tgz",
-      "integrity": "sha512-f55rivnOl7vK2aRkiB/zweJNRsSZ9Ub7xviHcTmcBh06M/eekdVsheHAHTJL7tmH7LhT7FW3wr8xuGBMwKRzhQ==",
-      "dev": true
-    },
-    "node_modules/@cloudscape-design/test-utils-core": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.4.tgz",
-      "integrity": "sha512-mV0713qUUK4QVL/gPROWPGYIWILWsAioJWS1iELux6wBXcTNt0d+zOKg5GKvWwIfeQMFTjoExVIx1QoTDm956w==",
-      "dev": true,
-      "dependencies": {
-        "css-selector-tokenizer": "^0.8.0",
-        "css.escape": "^1.5.1"
-      }
-    },
-    "node_modules/@cloudscape-design/theming-runtime": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.8.tgz",
-      "integrity": "sha512-kcXID107zaXNBiU8sSqxAMIAJklb3NXSh3qOqOfbZPWdYMrTatDvzhyMkR23WXc2QhbNXh4NAMZ9hRffmO+EtA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -12903,20 +12789,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-draggable": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
-      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
-      "dev": true,
-      "dependencies": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    },
     "node_modules/react-focus-lock": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.8.1.tgz",
@@ -17169,106 +17041,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@cloudscape-design/browser-test-tools": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.14.tgz",
-      "integrity": "sha512-IAu9/88bq8t0Lh+70vHpR1tz1IH88v2Tlwa11R0tqS0B5mh9hLrIoZMqisE4v3Ir5rn+QGxN3t5mSXfZd0wzPw==",
-      "dev": true,
-      "requires": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1233.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.25.2"
-      }
-    },
-    "@cloudscape-design/collection-hooks": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.16.tgz",
-      "integrity": "sha512-AAgyi3y34yTQ3TsFTyOQWUYX1ooelCil9e+OdFL5AAuzwas3Pv/WBYOu2rM5l3Lmw+bgt6EPf8rOJEXpbVXA5g==",
-      "dev": true,
-      "requires": {}
-    },
-    "@cloudscape-design/components": {
-      "version": "3.0.149",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.149.tgz",
-      "integrity": "sha512-ljM7Zrkms8Le8RiwtUwK6W5X2RWNZ2y6Mzre+bsV0WUwTq7zVqwMcC15EaZjb2LfmidMfkf4baC6KmY/iZ4PyQ==",
-      "dev": true,
-      "requires": {
-        "@cloudscape-design/collection-hooks": "^1.0.0",
-        "@cloudscape-design/test-utils-core": "^1.0.0",
-        "@cloudscape-design/theming-runtime": "^1.0.0",
-        "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.4.13",
-        "balanced-match": "^1.0.2",
-        "clsx": "^1.1.0",
-        "d3-shape": "^1.3.7",
-        "date-fns": "^2.25.0",
-        "mnth": "^2.0.0",
-        "react-focus-lock": "~2.8.1",
-        "react-keyed-flatten-children": "^1.3.0",
-        "react-resizable": "^1.11.1",
-        "react-transition-group": "^4.4.2",
-        "react-virtual": "^2.8.2",
-        "tslib": "^2.4.0",
-        "weekstart": "^1.1.0"
-      },
-      "dependencies": {
-        "react-resizable": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.11.1.tgz",
-          "integrity": "sha512-S70gbLaAYqjuAd49utRHibtHLrHXInh7GuOR+6OO6RO6uleQfuBnWmZjRABfqNEx3C3Z6VPLg0/0uOYFrkfu9Q==",
-          "dev": true,
-          "requires": {
-            "prop-types": "15.x",
-            "react-draggable": "^4.0.3"
-          }
-        },
-        "react-virtual": {
-          "version": "2.10.4",
-          "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
-          "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
-          "dev": true,
-          "requires": {
-            "@reach/observe-rect": "^1.1.0"
-          }
-        }
-      }
-    },
-    "@cloudscape-design/design-tokens": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/design-tokens/-/design-tokens-3.0.6.tgz",
-      "integrity": "sha512-fsJcv1EbybKpRJSke5Pw5wkr4zrsfqVdLKNjRbfxVhEVrJUjE49LOHm1y+CHjScDdEZ51/4AgUB/XEWAfI47mg==",
-      "dev": true
-    },
-    "@cloudscape-design/global-styles": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.6.tgz",
-      "integrity": "sha512-f55rivnOl7vK2aRkiB/zweJNRsSZ9Ub7xviHcTmcBh06M/eekdVsheHAHTJL7tmH7LhT7FW3wr8xuGBMwKRzhQ==",
-      "dev": true
-    },
-    "@cloudscape-design/test-utils-core": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.4.tgz",
-      "integrity": "sha512-mV0713qUUK4QVL/gPROWPGYIWILWsAioJWS1iELux6wBXcTNt0d+zOKg5GKvWwIfeQMFTjoExVIx1QoTDm956w==",
-      "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "^0.8.0",
-        "css.escape": "^1.5.1"
-      }
-    },
-    "@cloudscape-design/theming-runtime": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.8.tgz",
-      "integrity": "sha512-kcXID107zaXNBiU8sSqxAMIAJklb3NXSh3qOqOfbZPWdYMrTatDvzhyMkR23WXc2QhbNXh4NAMZ9hRffmO+EtA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.4.0"
-      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -25443,16 +25215,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
-      }
-    },
-    "react-draggable": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
-      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
-      "dev": true,
-      "requires": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
       }
     },
     "react-focus-lock": {

--- a/scripts/check-package-lock.js
+++ b/scripts/check-package-lock.js
@@ -11,6 +11,16 @@
 const fs = require('fs');
 const filenames = process.argv.slice(2);
 
+function unlock(packages) {
+  Object.keys(packages).forEach(dependencyName => {
+    if (dependencyName.includes('@cloudscape-design/')) {
+      delete packages[dependencyName];
+    }
+  });
+
+  return packages;
+}
+
 for (const filename of filenames) {
   const packageLock = require(filename);
 
@@ -18,10 +28,8 @@ for (const filename of filenames) {
     throw new Error('package-lock.json must have "lockfileVersion": 2');
   }
 
-  Object.keys(packageLock.packages).forEach(dependencyName => {
-    if (dependencyName.includes('@cloudscape-design/')) {
-      delete packageLock.packages[dependencyName];
-    }
-  });
+  packageLock.packages = unlock(packageLock.packages);
+  packageLock.dependencies = unlock(packageLock.dependencies);
+
   fs.writeFileSync(filename, JSON.stringify(packageLock, null, 2) + '\n');
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change makes sure that the check-package-lock script works with the new package-lock.json format in npm v8. Its essentially equivalent to this PR: https://github.com/cloudscape-design/theming-core/pull/30

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
