### PR TITLE
chore: Use correct remove button test-util on tags page

### DIFF
--- a/test/e2e/page/tags-page-object.ts
+++ b/test/e2e/page/tags-page-object.ts
@@ -25,7 +25,7 @@ export default class PageObject extends BasePageObject {
   }
 
   async removeTag(row: number) {
-    await this.click(this.findRow(row).findButton().toSelector());
+    await this.click(this.findRow(row).findRemoveButton().toSelector());
   }
 
   async undoTagRemoval(row: number) {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Self-explanatory. `.findButton()` finds _any_ button, but we already have a better test util, `.findRemoveButton()`, available.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
