### PR TITLE
feat: Allow listitem to have role=presentation

### DIFF
--- a/test/e2e/a11y.test.ts
+++ b/test/e2e/a11y.test.ts
@@ -29,6 +29,14 @@ function filterIgnored(results: Axe.Result[]) {
         return !chartIssue;
       }
 
+      // allow presentational dividers inside lists
+      if (result.id === 'list') {
+        const presentationRoleIssue = result.nodes.every(
+          node => node.failureSummary?.indexOf('role=presentation') !== -1
+        );
+        return !presentationRoleIssue;
+      }
+
       return true;
     }
     return false;


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/cloudscape-design/components/pull/800

*Description of changes:*
Axe a11y rule doesn't allow any elements besides `<li>, <script> or <template>` as a direct children of `<ul>`.
However, separators with role=presentation inside list is still a valid markup, as they will be removed from a11y tree and therefore won't interrupt the list.
A11y team confirmed that it's a valid use-case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
