### PR TITLE
chore: Stop delete confirmation label from wrapping

### DIFF
--- a/src/pages/delete-with-additional-confirmation/index.jsx
+++ b/src/pages/delete-with-additional-confirmation/index.jsx
@@ -277,18 +277,18 @@ function DeleteModal({ instances, visible, onDiscard, onDelete }) {
 
           <Box>To avoid accidental deletions, we ask you to provide additional written consent.</Box>
 
-          <ColumnLayout columns={2}>
-            <form onSubmit={handleDeleteSubmit}>
-              <FormField label={`To confirm this deletion, type "${deleteConsentText}".`}>
+          <form onSubmit={handleDeleteSubmit}>
+            <FormField label={`To confirm this deletion, type "${deleteConsentText}".`}>
+              <ColumnLayout columns={2}>
                 <Input
                   placeholder={deleteConsentText}
                   onChange={event => setDeleteInputText(event.detail.value)}
                   value={deleteInputText}
                   ariaRequired={true}
                 />
-              </FormField>
-            </form>
-          </ColumnLayout>
+              </ColumnLayout>
+            </FormField>
+          </form>
         </SpaceBetween>
       )}
     </Modal>


### PR DESCRIPTION
*Issue #, if available:* `CR-87372239`

*Description of changes:*

Changed the "Confirm" form field and input in the Delete modal so that the Form field label uses the full width, but the input itself only uses 50% of the width.

The new label text caused the label to wrap in certain scenarios (e.g. in Visual Refresh), which is not desired. Instead, we only want the Input to have reduced width.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
