### PR TITLE
chore: Increase details-tabs test window height

### DIFF
--- a/test/e2e/details-tabs-template.test.ts
+++ b/test/e2e/details-tabs-template.test.ts
@@ -9,6 +9,11 @@ describe('Details Tabs', () => {
       await browser.url('/details-tabs.html');
       const page = new Page(browser);
       await page.waitForPageLoaded();
+
+      // Increase window height to ensure sticky-scrollbar doesn't overlap
+      // clickable table elements in the standard viewport size
+      await page.setWindowSize({ width: 1200, height: 800 });
+
       await testFn(page);
     });
   };


### PR DESCRIPTION
*Description of changes:*

With the new sticky columns feature (https://github.com/cloudscape-design/components/pull/918), there is an increase in our sticky scrollbar z-index. It now overlaps the checkboxes and radio buttons in the table, which when trying to be clicked in the standard test's viewport size (1200*600), intercepts the click (see screenshot). This makes the test about clicking the first table item fail.

<img width="1245" alt="Screenshot 2023-04-19 at 09 37 42" src="https://user-images.githubusercontent.com/29541876/233004205-31d3194e-760c-4c46-a837-4eddc0c8d33f.png">


The solution presented here is to increase the window height by `200px` to avoid the scrollbar being on top of the targeted elements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
