### PR TITLE
chore: Use Table column reordering

### DIFF
--- a/src/i18n-strings/collection-preferences.ts
+++ b/src/i18n-strings/collection-preferences.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { CollectionPreferencesProps } from '@cloudscape-design/components';
+
+export const contentDisplayPreferenceI18nStrings: Partial<CollectionPreferencesProps.ContentDisplayPreference> = {
+  liveAnnouncementDndStarted: (position, total) => `Picked up item at position ${position} of ${total}`,
+  liveAnnouncementDndDiscarded: 'Reordering canceled',
+  liveAnnouncementDndItemReordered: (initialPosition, currentPosition, total) =>
+    initialPosition === currentPosition
+      ? `Moving item back to position ${currentPosition} of ${total}`
+      : `Moving item to position ${currentPosition} of ${total}`,
+  liveAnnouncementDndItemCommitted: (initialPosition, finalPosition, total) =>
+    initialPosition === finalPosition
+      ? `Item moved back to its original position ${initialPosition} of ${total}`
+      : `Item moved from position ${initialPosition} to position ${finalPosition} of ${total}`,
+  dragHandleAriaDescription:
+    "Use Space or Enter to activate drag for an item, then use the arrow keys to move the item's position. To complete the position move, use Space or Enter, or to discard the move, use Escape.",
+  dragHandleAriaLabel: 'Drag handle',
+};

--- a/src/i18n-strings/index.ts
+++ b/src/i18n-strings/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 export * from './app-layout';
+export * from './collection-preferences';
 export * from './flashbar';
 export * from './header';
 export * from './pagination';

--- a/src/pages/commons/table-config.jsx
+++ b/src/pages/commons/table-config.jsx
@@ -9,7 +9,7 @@ import {
   Input,
   Autosuggest,
 } from '@cloudscape-design/components';
-import { createTableSortLabelFn } from '../../i18n-strings';
+import { contentDisplayPreferenceI18nStrings, createTableSortLabelFn } from '../../i18n-strings';
 
 const rawColumns = [
   {
@@ -193,20 +193,15 @@ export const EDITABLE_COLUMN_DEFINITIONS = COLUMN_DEFINITIONS.map(column => {
   return column;
 });
 
-const VISIBLE_CONTENT_OPTIONS = [
-  {
-    label: 'Main distribution properties',
-    options: [
-      { id: 'id', label: 'Distribution ID', editable: false },
-      { id: 'state', label: 'State' },
-      { id: 'domainName', label: 'Domain name' },
-      { id: 'deliveryMethod', label: 'Delivery method' },
-      { id: 'sslCertificate', label: 'SSL certificate' },
-      { id: 'priceClass', label: 'Price class' },
-      { id: 'logging', label: 'Logging' },
-      { id: 'origin', label: 'Origin' },
-    ],
-  },
+const CONTENT_DISPLAY_OPTIONS = [
+  { id: 'id', label: 'Distribution ID', alwaysVisible: true },
+  { id: 'state', label: 'State' },
+  { id: 'domainName', label: 'Domain name' },
+  { id: 'deliveryMethod', label: 'Delivery method' },
+  { id: 'sslCertificate', label: 'SSL certificate' },
+  { id: 'priceClass', label: 'Price class' },
+  { id: 'logging', label: 'Logging' },
+  { id: 'origin', label: 'Origin' },
 ];
 
 export const PAGE_SIZE_OPTIONS = [
@@ -217,15 +212,16 @@ export const PAGE_SIZE_OPTIONS = [
 
 export const DEFAULT_PREFERENCES = {
   pageSize: 30,
-  visibleContent: ['id', 'domainName', 'deliveryMethod', 'sslCertificate', 'status', 'state'],
-  wrapLines: false,
-  stripedRows: false,
-  contentDensity: 'comfortable',
-};
-
-export const EDITABLE_PREFERENCES = {
-  pageSize: 30,
-  visibleContent: ['id', 'domainName', 'deliveryMethod', 'sslCertificate', 'state'],
+  contentDisplay: [
+    { id: 'id', visible: true },
+    { id: 'state', visible: true },
+    { id: 'domainName', visible: true },
+    { id: 'deliveryMethod', visible: true },
+    { id: 'sslCertificate', visible: true },
+    { id: 'priceClass', visible: false },
+    { id: 'logging', visible: false },
+    { id: 'origin', visible: false },
+  ],
   wrapLines: false,
   stripedRows: false,
   contentDensity: 'comfortable',
@@ -236,7 +232,7 @@ export const Preferences = ({
   setPreferences,
   disabled,
   pageSizeOptions = PAGE_SIZE_OPTIONS,
-  visibleContentOptions = VISIBLE_CONTENT_OPTIONS,
+  contentDisplayOptions = CONTENT_DISPLAY_OPTIONS,
 }) => (
   <CollectionPreferences
     title="Preferences"
@@ -261,9 +257,11 @@ export const Preferences = ({
       label: 'Compact mode',
       description: 'Select to display content in a denser, more compact mode',
     }}
-    visibleContentPreference={{
-      title: 'Select visible columns',
-      options: visibleContentOptions,
+    contentDisplayPreference={{
+      title: 'Column preferences',
+      description: 'Customize the columns visibility and order.',
+      options: contentDisplayOptions,
+      ...contentDisplayPreferenceI18nStrings,
     }}
   />
 );

--- a/src/pages/server-side-table-property-filter/index.jsx
+++ b/src/pages/server-side-table-property-filter/index.jsx
@@ -83,7 +83,7 @@ function ServerSidePropertyFilterTable({ columnDefinitions, saveWidths, loadHelp
       sortingColumn={sortingColumn}
       sortingDescending={sortingDescending}
       columnDefinitions={columnDefinitions}
-      visibleColumns={preferences.visibleContent}
+      columnDisplay={preferences.contentDisplay}
       ariaLabels={distributionTableAriaLabels}
       renderAriaLive={renderAriaLive}
       selectionType="multi"

--- a/src/pages/server-side-table/index.jsx
+++ b/src/pages/server-side-table/index.jsx
@@ -72,7 +72,7 @@ function ServerSideTable({ columnDefinitions, saveWidths, loadHelpPanelContent }
       sortingColumn={sortingColumn}
       sortingDescending={descendingSorting}
       columnDefinitions={columnDefinitions}
-      visibleColumns={preferences.visibleContent}
+      columnDisplay={preferences.contentDisplay}
       ariaLabels={distributionTableAriaLabels}
       renderAriaLive={renderAriaLive}
       selectionType="multi"

--- a/src/pages/split-panel-comparison/index.jsx
+++ b/src/pages/split-panel-comparison/index.jsx
@@ -84,6 +84,7 @@ const App = () => {
             />
           }
           columnDefinitions={COLUMN_DEFINITIONS_MAIN}
+          columnDisplay={preferences.contentDisplay}
           items={items}
           variant="full-page"
           stickyHeader={true}

--- a/src/pages/split-panel-comparison/table-config.jsx
+++ b/src/pages/split-panel-comparison/table-config.jsx
@@ -12,17 +12,12 @@ export const EC2Preferences = props => (
       { value: 30, label: '30 instances' },
       { value: 50, label: '50 instances' },
     ]}
-    visibleContentOptions={[
-      {
-        label: 'Main instance properties',
-        options: [
-          { id: 'id', label: 'Instance ID', editable: false },
-          { id: 'type', label: 'Instance type' },
-          { id: 'publicDns', label: 'Public DNS' },
-          { id: 'monitoring', label: 'Monitoring' },
-          { id: 'state', label: 'Instance state' },
-        ],
-      },
+    contentDisplayOptions={[
+      { id: 'id', label: 'Instance ID', alwaysVisible: true },
+      { id: 'type', label: 'Instance type' },
+      { id: 'publicDns', label: 'Public DNS' },
+      { id: 'monitoring', label: 'Monitoring' },
+      { id: 'state', label: 'Instance state' },
     ]}
     {...props}
   />
@@ -95,7 +90,13 @@ export const SELECTION_LABELS = {
 
 export const DEFAULT_PREFERENCES = {
   pageSize: 30,
-  visibleContent: ['id', 'type', 'publicDns', 'monitoring', 'state'],
+  contentDisplay: [
+    { id: 'id', visible: true },
+    { id: 'type', visible: true },
+    { id: 'publicDns', visible: true },
+    { id: 'monitoring', visible: true },
+    { id: 'state', visible: true },
+  ],
   wrapLines: false,
   stripedRows: false,
   contentDensity: 'comfortable',

--- a/src/pages/split-panel-multiple/index.jsx
+++ b/src/pages/split-panel-multiple/index.jsx
@@ -91,6 +91,7 @@ const App = () => {
           variant="full-page"
           stickyHeader={true}
           columnDefinitions={COLUMN_DEFINITIONS_MAIN}
+          columnDisplay={preferences.contentDisplay}
           items={items}
           selectionType="multi"
           ariaLabels={SELECTION_LABELS}

--- a/src/pages/table-date-filter/index.jsx
+++ b/src/pages/table-date-filter/index.jsx
@@ -7,7 +7,12 @@ import DataProvider from '../commons/data-provider';
 import { useColumnWidths } from '../commons/use-column-widths';
 import { Breadcrumbs, ToolsContent } from '../table/common-components';
 import { CustomAppLayout, Navigation, Notifications } from '../commons/common-components';
-import { COLUMN_DEFINITIONS, FILTERING_PROPERTIES, DEFAULT_PREFERENCES } from './table-date-filter-config';
+import {
+  CONTENT_DISPLAY_OPTIONS,
+  COLUMN_DEFINITIONS,
+  FILTERING_PROPERTIES,
+  DEFAULT_PREFERENCES,
+} from './table-date-filter-config';
 import { PropertyFilterTable } from '../table-property-filter/property-filter-table';
 
 import '../../styles/table-date-filter.scss';
@@ -40,6 +45,7 @@ function App() {
             appLayout.current?.focusToolsClose();
           }}
           columnDefinitions={columnDefinitions}
+          contentDisplayOptions={CONTENT_DISPLAY_OPTIONS}
           saveWidths={saveWidths}
           preferences={preferences}
           setPreferences={setPreferences}

--- a/src/pages/table-date-filter/table-date-filter-config.jsx
+++ b/src/pages/table-date-filter/table-date-filter-config.jsx
@@ -79,9 +79,31 @@ const rawColumns = [
 
 export const COLUMN_DEFINITIONS = rawColumns.map(column => ({ ...column, ariaLabel: createTableSortLabelFn(column) }));
 
+export const CONTENT_DISPLAY_OPTIONS = [
+  { id: 'id', label: 'Distribution ID', alwaysVisible: true },
+  { id: 'state', label: 'State' },
+  { id: 'domainName', label: 'Domain name' },
+  { id: 'createdAt', label: 'Created at' },
+  { id: 'deliveryMethod', label: 'Delivery method' },
+  { id: 'sslCertificate', label: 'SSL certificate' },
+  { id: 'priceClass', label: 'Price class' },
+  { id: 'logging', label: 'Logging' },
+  { id: 'origin', label: 'Origin' },
+];
+
 export const DEFAULT_PREFERENCES = {
   pageSize: 30,
-  visibleContent: ['id', 'state', 'domainName', 'createdAt', 'deliveryMethod', 'sslCertificate'],
+  contentDisplay: [
+    { id: 'id', visible: true },
+    { id: 'state', visible: true },
+    { id: 'domainName', visible: true },
+    { id: 'createdAt', visible: true },
+    { id: 'deliveryMethod', visible: true },
+    { id: 'sslCertificate', visible: true },
+    { id: 'priceClass', visible: false },
+    { id: 'logging', visible: false },
+    { id: 'origin', visible: false },
+  ],
   wraplines: false,
   stripedRows: false,
   contentDensity: 'comfortable',

--- a/src/pages/table-editable/index.jsx
+++ b/src/pages/table-editable/index.jsx
@@ -25,7 +25,7 @@ import DataProvider from '../commons/data-provider';
 import { useColumnWidths } from '../commons/use-column-widths';
 import { Breadcrumbs, ToolsContent } from '../table/common-components';
 import {
-  EDITABLE_PREFERENCES,
+  DEFAULT_PREFERENCES,
   EDITABLE_COLUMN_DEFINITIONS,
   Preferences,
   serverSideErrorsStore,
@@ -48,7 +48,7 @@ function TableContent({ loadHelpPanelContent, distributions }) {
   const [columnDefinitions, saveWidths] = useColumnWidths('React-EditableTable-Widths', EDITABLE_COLUMN_DEFINITIONS);
   const [preferences, setPreferences] = useLocalStorage(
     'React-EditableDistributionsTable-Preferences',
-    EDITABLE_PREFERENCES
+    DEFAULT_PREFERENCES
   );
   const [itemsSnap, setItemsSnap] = useState(null);
 
@@ -125,7 +125,7 @@ function TableContent({ loadHelpPanelContent, distributions }) {
     <Table
       {...tableCollectionProps}
       columnDefinitions={columnDefinitions}
-      visibleColumns={preferences.visibleContent}
+      columnDisplay={preferences.contentDisplay}
       items={itemsSnap || items}
       submitEdit={handleSubmit}
       ariaLabels={distributionEditableTableAriaLabels}

--- a/src/pages/table-property-filter/property-filter-table.jsx
+++ b/src/pages/table-property-filter/property-filter-table.jsx
@@ -24,6 +24,7 @@ export function PropertyFilterTable({
   data,
   loadHelpPanelContent,
   columnDefinitions,
+  contentDisplayOptions,
   saveWidths,
   preferences,
   setPreferences,
@@ -54,7 +55,7 @@ export function PropertyFilterTable({
       {...collectionProps}
       items={items}
       columnDefinitions={columnDefinitions}
-      visibleColumns={preferences.visibleContent}
+      columnDisplay={preferences.contentDisplay}
       ariaLabels={distributionTableAriaLabels}
       renderAriaLive={renderAriaLive}
       selectionType="multi"
@@ -82,7 +83,13 @@ export function PropertyFilterTable({
         />
       }
       pagination={<Pagination {...paginationProps} ariaLabels={paginationAriaLabels(paginationProps.pagesCount)} />}
-      preferences={<Preferences preferences={preferences} setPreferences={setPreferences} />}
+      preferences={
+        <Preferences
+          preferences={preferences}
+          setPreferences={setPreferences}
+          contentDisplayOptions={contentDisplayOptions}
+        />
+      }
     />
   );
 }

--- a/src/pages/table-select-filter/index.jsx
+++ b/src/pages/table-select-filter/index.jsx
@@ -3,7 +3,7 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useCollection } from '@cloudscape-design/collection-hooks';
-import { COLUMN_DEFINITIONS, SEARCHABLE_COLUMNS, VISIBLE_CONTENT_OPTIONS } from './table-select-filter-config';
+import { COLUMN_DEFINITIONS, SEARCHABLE_COLUMNS, CONTENT_DISPLAY_OPTIONS } from './table-select-filter-config';
 import { Preferences } from '../commons/table-config';
 import { Button, Input, Pagination, SpaceBetween, Select, Table } from '@cloudscape-design/components';
 import { Navigation, Breadcrumbs, ToolsContent } from './table-select-filter-components';
@@ -58,7 +58,17 @@ function TableSelectFilter({ loadHelpPanelContent }) {
   const [instanceClass, setInstanceClass] = useState(defaultClass);
   const [preferences, setPreferences] = useLocalStorage('React-DBInstancesTable-Preferences', {
     pageSize: 30,
-    visibleContent: ['id', 'engine', 'version', 'status', 'activity', 'class'],
+    contentDisplay: [
+      { id: 'id', visible: true },
+      { id: 'engine', visible: true },
+      { id: 'version', visible: true },
+      { id: 'status', visible: true },
+      { id: 'activity', visible: true },
+      { id: 'maint', visible: false },
+      { id: 'class', visible: true },
+      { id: 'zone', visible: false },
+      { id: 'iops', visible: false },
+    ],
     wrapLines: false,
     stripedRows: false,
     contentDensity: 'comfortable',
@@ -100,7 +110,7 @@ function TableSelectFilter({ loadHelpPanelContent }) {
     <Table
       {...collectionProps}
       columnDefinitions={columnDefinitions}
-      visibleColumns={preferences.visibleContent}
+      columnDisplay={preferences.contentDisplay}
       items={items}
       variant="full-page"
       stickyHeader={true}
@@ -185,7 +195,7 @@ function TableSelectFilter({ loadHelpPanelContent }) {
         <Preferences
           preferences={preferences}
           setPreferences={setPreferences}
-          visibleContentOptions={VISIBLE_CONTENT_OPTIONS}
+          contentDisplayOptions={CONTENT_DISPLAY_OPTIONS}
         />
       }
     />

--- a/src/pages/table-select-filter/table-select-filter-config.jsx
+++ b/src/pages/table-select-filter/table-select-filter-config.jsx
@@ -66,21 +66,16 @@ export const COLUMN_DEFINITIONS = rawColumns.map(column => ({ ...column, ariaLab
 
 export const SEARCHABLE_COLUMNS = ['id', 'engine', 'version', 'status', 'class', 'activity', 'zone', 'iops', 'maint'];
 
-export const VISIBLE_CONTENT_OPTIONS = [
-  {
-    label: 'Main instance properties',
-    options: [
-      { id: 'id', label: 'DB instance', editable: false },
-      { id: 'status', label: 'Status' },
-      { id: 'engine', label: 'Engine' },
-      { id: 'version', label: 'Engine version' },
-      { id: 'activity', label: 'Active connections' },
-      { id: 'maint', label: 'Maintenance' },
-      { id: 'class', label: 'Class' },
-      { id: 'zone', label: 'Zone' },
-      { id: 'iops', label: 'IOPS' },
-    ],
-  },
+export const CONTENT_DISPLAY_OPTIONS = [
+  { id: 'id', label: 'DB instance', alwaysVisible: true },
+  { id: 'status', label: 'Status' },
+  { id: 'engine', label: 'Engine' },
+  { id: 'version', label: 'Engine version' },
+  { id: 'activity', label: 'Active connections' },
+  { id: 'maint', label: 'Maintenance' },
+  { id: 'class', label: 'Class' },
+  { id: 'zone', label: 'Zone' },
+  { id: 'iops', label: 'IOPS' },
 ];
 
 export const PAGE_SIZE_OPTIONS = [

--- a/src/pages/table/index.jsx
+++ b/src/pages/table/index.jsx
@@ -45,7 +45,7 @@ function TableContent({ distributions, loadHelpPanelContent }) {
     <Table
       {...collectionProps}
       columnDefinitions={columnDefinitions}
-      visibleColumns={preferences.visibleContent}
+      columnDisplay={preferences.contentDisplay}
       items={items}
       selectionType="multi"
       ariaLabels={distributionTableAriaLabels}

--- a/test/e2e/common/table/table-preferences-tests.ts
+++ b/test/e2e/common/table/table-preferences-tests.ts
@@ -43,10 +43,10 @@ export default function commonPreferencesTests(setupTest: {
       'has only 2 columns when changing all editable columns to invisible',
       setupTest(async page => {
         await page.openTablePreferences();
-        await page.setTablePreferenceTableColumns(2);
-        await page.setTablePreferenceTableColumns(3);
-        await page.setTablePreferenceTableColumns(4);
-        await page.setTablePreferenceTableColumns(5);
+        await page.toggleColumnVisibility(2);
+        await page.toggleColumnVisibility(3);
+        await page.toggleColumnVisibility(4);
+        await page.toggleColumnVisibility(5);
         await page.confirmTablePreferenceChanges();
 
         expect(await page.countTableColumns()).toBe(2);
@@ -57,13 +57,29 @@ export default function commonPreferencesTests(setupTest: {
       'has 9 columns when changing all editable columns to visible',
       setupTest(async page => {
         await page.openTablePreferences();
-        await page.setTablePreferenceTableColumns(6);
-        await page.setTablePreferenceTableColumns(7);
-        await page.setTablePreferenceTableColumns(8);
+        await page.toggleColumnVisibility(6);
+        await page.toggleColumnVisibility(7);
+        await page.toggleColumnVisibility(8);
         await page.confirmTablePreferenceChanges();
 
         expect(await page.countTableColumns()).toBe(9);
       })
     );
+
+    test('reorders columns', () => {
+      setupTest(async page => {
+        await page.openTablePreferences();
+        await page.reorderColumn(0, 1);
+        await page.confirmTablePreferenceChanges();
+
+        expect(await page.getColumnHeaderTexts()).toBe([
+          'State',
+          'Distribution ID',
+          'Domain name',
+          'Delivery method',
+          'SSL certificate',
+        ]);
+      });
+    });
   });
 }

--- a/test/e2e/page/table-page-object.ts
+++ b/test/e2e/page/table-page-object.ts
@@ -29,6 +29,11 @@ export default class TablePageObject extends AppLayoutPage {
     return this.getElementsCount(this.tableWrapper.findColumnHeaders().toSelector());
   }
 
+  async getColumnHeaderTexts() {
+    const headers = await this.browser.$$(this.tableWrapper.findColumnHeaders().toSelector());
+    return headers.map(header => header.getText());
+  }
+
   // Table - Header Buttons
   protected async isTableHeaderButtonEnabled(index: number) {
     const el = await this.browser.$(
@@ -109,16 +114,35 @@ export default class TablePageObject extends AppLayoutPage {
     await el.click();
   }
 
-  async setTablePreferenceTableColumns(index: number) {
+  async toggleColumnVisibility(index: number) {
     const el = await this.browser.$(
       this.tableWrapper
         .findCollectionPreferences()
         .findModal()
-        .findVisibleContentPreference()
-        .findToggleByIndex(1, index)
+        .findContentDisplayPreference()
+        .findOptionByIndex(index)
+        .findVisibilityToggle()
         .findNativeInput()
         .toSelector()
     );
     await el.click();
+  }
+
+  async reorderColumn(index: number, positionDelta: number) {
+    const options = this.tableWrapper
+      .findCollectionPreferences()
+      .findModal()
+      .findContentDisplayPreference()
+      .findOptions();
+    const activeColumn = options.get(index);
+    const activeColumnSelector = options.get(index).toSelector();
+    const activeColumnElement = await this.browser.$(activeColumnSelector);
+    const targetColumnElement = await this.browser.$(options.get(index + positionDelta).toSelector());
+    const activeColumnCenter =
+      (await activeColumnElement.getLocation('y')) + (await activeColumnElement.getSize('height')) / 2;
+    const targetColumnCenter =
+      (await targetColumnElement.getLocation('y')) + (await targetColumnElement.getSize('height')) / 2;
+    const offset = targetColumnCenter - activeColumnCenter;
+    this.dragAndDrop(activeColumn.findDragHandle().toSelector(), 0, offset);
   }
 }

--- a/test/e2e/table-select-filter.test.ts
+++ b/test/e2e/table-select-filter.test.ts
@@ -216,10 +216,10 @@ describe('Table Select Filter', () => {
       'has only 3 columns when changing all editable columns to invisible',
       setupTest(async page => {
         await page.openTablePreferences();
-        await page.setTablePreferenceTableColumns(2);
-        await page.setTablePreferenceTableColumns(3);
-        await page.setTablePreferenceTableColumns(4);
-        await page.setTablePreferenceTableColumns(5);
+        await page.toggleColumnVisibility(2);
+        await page.toggleColumnVisibility(3);
+        await page.toggleColumnVisibility(4);
+        await page.toggleColumnVisibility(5);
         await page.confirmTablePreferenceChanges();
 
         expect(await page.countTableColumns()).toBe(3);
@@ -230,9 +230,9 @@ describe('Table Select Filter', () => {
       'has 10 columns when changing all editable columns to visible',
       setupTest(async page => {
         await page.openTablePreferences();
-        await page.setTablePreferenceTableColumns(6);
-        await page.setTablePreferenceTableColumns(8);
-        await page.setTablePreferenceTableColumns(9);
+        await page.toggleColumnVisibility(6);
+        await page.toggleColumnVisibility(8);
+        await page.toggleColumnVisibility(9);
         await page.confirmTablePreferenceChanges();
 
         expect(await page.countTableColumns()).toBe(10);


### PR DESCRIPTION
*Description of changes:*

This PR changes existing Table-related examples to use the new content display preference instead of the visible content display preference.

Additionally, it fixes two existing issues found along the way:
  - In the table with date filter example,  a column was rendered in the table but not listed in the Collection preferences modal ([link](https://cloudscape.aws.dev/examples/react/table-date-filter.html))
  - In the split panel examples, where a table is shown, the customization made in the collection preferences modal was not having effect on the table (see [here](https://cloudscape.design/examples/react/split-panel-multiple.html) and [here](https://cloudscape.design/examples/react/split-panel-comparison.html))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
