### PR TITLE
chore: Use new `minColumnWidth` property for Service overview widget

### DIFF
--- a/src/pages/dashboard/widgets/service-overview/index.tsx
+++ b/src/pages/dashboard/widgets/service-overview/index.tsx
@@ -26,7 +26,7 @@ function ServiceOverviewHeader() {
 
 function ServiceOverviewWidget() {
   return (
-    <ColumnLayout columns={4} variant="text-grid">
+    <ColumnLayout columns={4} variant="text-grid" minColumnWidth={170}>
       <div>
         <Box variant="awsui-key-label">Running instances</Box>
         <Link variant="awsui-value-large" href="#">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use the new `minColumnWidth` property that was introduced for this use-case. See https://github.com/cloudscape-design/components/pull/1123.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
