### PR TITLE
chore: Update y-value for widget drag and drop test after header updates

### DIFF
--- a/test/e2e/configurable-dashboard.test.ts
+++ b/test/e2e/configurable-dashboard.test.ts
@@ -20,7 +20,7 @@ class ConfigurableDashboardPageObject extends BasePageObject {
 
   async addNewWidget() {
     await this.click('button=Add widget');
-    await this.moveWidget(paletteWrapper.findItemById('operationalMetrics').findDragHandle().toSelector(), -800, 200);
+    await this.moveWidget(paletteWrapper.findItemById('operationalMetrics').findDragHandle().toSelector(), -800, 180);
   }
 
   async moveWidget(selector: string, xOffset: number, yOffset: number) {


### PR DESCRIPTION
*Issue #, if available:* 
More info in CR-96406829

Update the y value for dragging in a widget.

Why?
This is prep for components [#1317](https://github.com/cloudscape-design/components/pull/1317), which reduces the height of heading elements, making the old value not put the widget in the right place.
