### PR TITLE
chore: Upgrade workflows to NodeJS 18+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm it


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes workflow to use NodeJS 18 for building. We're also upgrading the checkout action to v4 because it uses NodeJS 20 instead of 16: https://github.com/actions/checkout/releases/tag/v4.0.0. There is no version that uses NodeJS 18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
