### PR TITLE
chore: Add accessible names for large number-only links

### DIFF
--- a/src/pages/commons/common-components.tsx
+++ b/src/pages/commons/common-components.tsx
@@ -66,11 +66,3 @@ export const CustomAppLayout = forwardRef<AppLayoutProps.Ref, AppLayoutProps>((p
     </I18nProvider>
   );
 });
-
-export const CounterLink = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <Link variant="awsui-value-large" href="#">
-      {children}
-    </Link>
-  );
-};

--- a/src/pages/dashboard/widgets/service-overview/index.tsx
+++ b/src/pages/dashboard/widgets/service-overview/index.tsx
@@ -29,25 +29,25 @@ function ServiceOverviewWidget() {
     <ColumnLayout columns={4} variant="text-grid" minColumnWidth={170}>
       <div>
         <Box variant="awsui-key-label">Running instances</Box>
-        <Link variant="awsui-value-large" href="#">
+        <Link variant="awsui-value-large" href="#" ariaLabel="Running instances (14)">
           14
         </Link>
       </div>
       <div>
         <Box variant="awsui-key-label">Volumes</Box>
-        <Link variant="awsui-value-large" href="#">
+        <Link variant="awsui-value-large" href="#" ariaLabel="Volumes (126)">
           126
         </Link>
       </div>
       <div>
         <Box variant="awsui-key-label">Security groups</Box>
-        <Link variant="awsui-value-large" href="#">
+        <Link variant="awsui-value-large" href="#" ariaLabel="Security groups (116)">
           116
         </Link>
       </div>
       <div>
         <Box variant="awsui-key-label">Load balancers</Box>
-        <Link variant="awsui-value-large" href="#">
+        <Link variant="awsui-value-large" href="#" ariaLabel="Load balancers (28)">
           28
         </Link>
       </div>

--- a/src/pages/split-panel-comparison/utils.jsx
+++ b/src/pages/split-panel-comparison/utils.jsx
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import React, { useState, useEffect } from 'react';
-import { Header, Table, BreadcrumbGroup, ColumnLayout, Box } from '@cloudscape-design/components';
+import { Header, Table, BreadcrumbGroup, ColumnLayout, Box, Link } from '@cloudscape-design/components';
 import { COLUMN_DEFINITIONS_PANEL_CONTENT_SINGLE, SELECTION_LABELS } from './table-config';
-import { CounterLink } from '../commons/common-components';
 import { isVisualRefresh } from '../../common/apply-mode';
 
 const EMPTY_PANEL_CONTENT = {
@@ -74,19 +73,27 @@ export const getPanelContentMultiple = items => {
       <ColumnLayout columns="4" variant="text-grid">
         <div>
           <Box variant="awsui-key-label">Running instances</Box>
-          <CounterLink>{enabled}</CounterLink>
+          <Link variant="awsui-value-large" href="#" ariaLabel={`Running instances (${enabled})`}>
+            {enabled}
+          </Link>
         </div>
         <div>
           <Box variant="awsui-key-label">Volumes</Box>
-          <CounterLink>{volumes}</CounterLink>
+          <Link variant="awsui-value-large" href="#" ariaLabel={`Volumes (${volumes})`}>
+            {volumes}
+          </Link>
         </div>
         <div>
           <Box variant="awsui-key-label">Security groups</Box>
-          <CounterLink>{securityGroups}</CounterLink>
+          <Link variant="awsui-value-large" href="#" ariaLabel={`Security groups (${securityGroups})`}>
+            {securityGroups}
+          </Link>
         </div>
         <div>
           <Box variant="awsui-key-label">Load balancers</Box>
-          <CounterLink>{loadBalancers}</CounterLink>
+          <Link variant="awsui-value-large" href="#" ariaLabel={`Load balancers (${loadBalancers})`}>
+            {loadBalancers}
+          </Link>
         </div>
       </ColumnLayout>
     ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* These large number links in dashboard and split panel could use some additional context to improve their accessible name.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
