### PR TITLE
Removed superfluous attributes from profileActions.

### DIFF
--- a/src/pages/non-console/index.jsx
+++ b/src/pages/non-console/index.jsx
@@ -65,11 +65,10 @@ const i18nStrings = {
 };
 
 const profileActions = [
-  { type: 'button', id: 'profile', text: 'Profile' },
-  { type: 'button', id: 'preferences', text: 'Preferences' },
-  { type: 'button', id: 'security', text: 'Security' },
+  { id: 'profile', text: 'Profile' },
+  { id: 'preferences', text: 'Preferences' },
+  { id: 'security', text: 'Security' },
   {
-    type: 'menu-dropdown',
     id: 'support-group',
     text: 'Support',
     items: [
@@ -84,7 +83,7 @@ const profileActions = [
       { id: 'support', text: 'Customer support' },
     ],
   },
-  { type: 'button', id: 'signout', text: 'Sign out' },
+  { id: 'signout', text: 'Sign out' },
 ];
 
 const columnDefinitions = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removed superfluous attributes from profileActions. The types I removed do not exist on the `Item` interface, but do on the parent `Utility` interface. I believe they were included erroneously.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
