### PR TITLE
Chore: Add bottom border to demo header

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -17,6 +17,7 @@ body {
   margin: 0;
   background-color: #0f1b2a;
   font-family: cs.$font-family-base;
+  border-bottom: solid 1px #414d5c;
 }
 
 ul.menu-list {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Visual Design squad wants to add a bottom border to the demo header to visually separate it from the contents.
![demo-header](https://github.com/cloudscape-design/demos/assets/28137165/ff6da940-34be-4fec-8e69-c8f87e39f266)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
