### PR TITLE
chore: Add  bottom border to demo header

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -17,12 +17,13 @@ body {
   margin: 0;
   background-color: #0f1b2a;
   font-family: cs.$font-family-base;
+  border-bottom: solid 1px #414d5c;
 }
 
 ul.menu-list {
   display: flex;
   align-items: center;
-  height: 40px;
+  height: 39px;
   margin: 0;
   padding: 0 40px;
   list-style: none;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Visual Design squad wants to add a bottom border to the demo header to visually separate it from the contents.

![demo-header](https://github.com/cloudscape-design/demos/assets/28137165/dc7c8121-377a-452c-af16-05b13f0346a3)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
