### PR TITLE
chore: Update list separator to use new design token

### DIFF
--- a/src/pages/commons/separated-list/styles.module.scss
+++ b/src/pages/commons/separated-list/styles.module.scss
@@ -9,7 +9,7 @@
   padding: 0;
 
   li {
-    border-top: 1px solid cs.$color-border-divider-default;
+    border-top: 1px solid cs.$color-border-divider-secondary;
     padding: 0.8rem 0;
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Use newly introduced design token `color-border-divider-secondary` in Service homepage demo.

The new token is meant for horizontal dividers in tables, lists, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
