### PR TITLE
feat: Add new 'does not start with' property filter operator to demos

### DIFF
--- a/src/common/property-filter-operators.ts
+++ b/src/common/property-filter-operators.ts
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+export const stringOperators = [':', '!:', '=', '!=', '^', '!^'];

--- a/src/fake-server/distributions.js
+++ b/src/fake-server/distributions.js
@@ -23,6 +23,10 @@ const getComparatorForOperator = operator => (a, b) => {
       return (a + '').toLowerCase().indexOf((b + '').toLowerCase()) > -1;
     case '!:':
       return (a + '').toLowerCase().indexOf((b + '').toLowerCase()) === -1;
+    case '^':
+      return (a + '').toLowerCase().startsWith((b + '').toLowerCase());
+    case '!^':
+      return !(a + '').toLowerCase().startsWith((b + '').toLowerCase());
   }
   return false;
 };

--- a/src/pages/table-date-filter/table-date-filter-config.jsx
+++ b/src/pages/table-date-filter/table-date-filter-config.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { StatusIndicator, Link } from '@cloudscape-design/components';
 import { createTableSortLabelFn } from '../../i18n-strings';
 import { DateTimeForm, formatDateTime } from './table-date-filter-forms';
+import { stringOperators } from '../../common/property-filter-operators';
 
 const rawColumns = [
   {
@@ -114,38 +115,38 @@ export const FILTERING_PROPERTIES = [
     propertyLabel: 'Domain name',
     key: 'domainName',
     groupValuesLabel: 'Domain name values',
-    operators: [':', '!:', '=', '!='],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Delivery method',
     key: 'deliveryMethod',
     groupValuesLabel: 'Delivery method values',
-    operators: [':', '!:', '=', '!='],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Price class',
     key: 'priceClass',
     groupValuesLabel: 'Price class values',
-    operators: [':', '!:', '=', '!='],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Origin',
     key: 'origin',
     groupValuesLabel: 'Origin values',
-    operators: [':', '!:', '=', '!='],
+    operators: stringOperators,
   },
-  { propertyLabel: 'State', key: 'state', groupValuesLabel: 'State values', operators: [':', '!:', '=', '!='] },
+  { propertyLabel: 'State', key: 'state', groupValuesLabel: 'State values', operators: stringOperators },
   {
     propertyLabel: 'Logging',
     key: 'logging',
     groupValuesLabel: 'Logging values',
-    operators: [':', '!:', '=', '!='],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'SSL certificate',
     key: 'sslCertificate',
     groupValuesLabel: 'SSL certificate values',
-    operators: [':', '!:', '=', '!='],
+    operators: stringOperators,
   },
   {
     key: 'date',

--- a/src/pages/table-property-filter/table-property-filter-config.ts
+++ b/src/pages/table-property-filter/table-property-filter-config.ts
@@ -1,47 +1,49 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
+import { stringOperators } from '../../common/property-filter-operators';
+
 export const FILTERING_PROPERTIES = [
   {
     propertyLabel: 'Domain name',
     key: 'domainName',
     groupValuesLabel: 'Domain name values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Delivery method',
     key: 'deliveryMethod',
     groupValuesLabel: 'Delivery method values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Price class',
     key: 'priceClass',
     groupValuesLabel: 'Price class values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Origin',
     key: 'origin',
     groupValuesLabel: 'Origin values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'Status',
     key: 'status',
     groupValuesLabel: 'Status values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
-  { propertyLabel: 'State', key: 'state', groupValuesLabel: 'State values', operators: [':', '!:', '=', '!=', '^'] },
+  { propertyLabel: 'State', key: 'state', groupValuesLabel: 'State values', operators: stringOperators },
   {
     propertyLabel: 'Logging',
     key: 'logging',
     groupValuesLabel: 'Logging values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
   {
     propertyLabel: 'SSL certificate',
     key: 'sslCertificate',
     groupValuesLabel: 'SSL certificate values',
-    operators: [':', '!:', '=', '!=', '^'],
+    operators: stringOperators,
   },
 ];

--- a/src/resources/distributionsFilteringProperties.json
+++ b/src/resources/distributionsFilteringProperties.json
@@ -3,62 +3,62 @@
     "propertyLabel": "Domain name",
     "key": "domainName",
     "groupValuesLabel": "Domain name values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "Delivery method",
     "key": "deliveryMethod",
     "groupValuesLabel": "Delivery method values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "Price class",
     "key": "priceClass",
     "groupValuesLabel": "Price class values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "Origin",
     "key": "origin",
     "groupValuesLabel": "Origin values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "Status",
     "key": "status",
     "groupValuesLabel": "Status values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "State",
     "key": "state",
     "groupValuesLabel": "State values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "Logging",
     "key": "logging",
     "groupValuesLabel": "Logging values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "SSL certificate",
     "key": "sslCertificate",
     "groupValuesLabel": "SSL certificate values",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "environment",
     "key": "tag-indicator__environment",
     "groupValuesLabel": "Tags with key 'environment'",
     "group": "tags",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   },
   {
     "propertyLabel": "department",
     "key": "tag-indicator__department",
     "groupValuesLabel": "Tags with key 'department'",
     "group": "tags",
-    "operators": [":", "!:", "=", "!=", "^"]
+    "operators": [":", "!:", "=", "!=", "^", "!^"]
   }
 ]

--- a/test/e2e/common/table/table-property-filtering-tests.ts
+++ b/test/e2e/common/table/table-property-filtering-tests.ts
@@ -30,7 +30,7 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
         await page.selectOption(1);
 
         await page.waitUntilPropertyFilterLoaded();
-        await expect(page.countDropdownItems()).resolves.toBe(5);
+        await expect(page.countDropdownItems()).resolves.toBe(6);
       })
     );
 
@@ -133,6 +133,30 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await expect(page.countTokens()).resolves.toBe(2);
         await expect(page.countTableRows()).resolves.toBe(11);
+
+        await page.focusFilter();
+        await page.selectOption(1);
+        await page.waitUntilPropertyFilterLoaded();
+        await page.selectOption(6); // "Does not start with" operator
+        await page.search('abc');
+        await page.keys(['Enter']);
+
+        await page.waitUntilLoaded();
+
+        await expect(page.countTokens()).resolves.toBe(3);
+        await expect(page.countTableRows()).resolves.toBe(7);
+
+        await page.focusFilter();
+        await page.selectOption(1);
+        await page.waitUntilPropertyFilterLoaded();
+        await page.selectOption(5); // "Starts with" operator
+        await page.search('123');
+        await page.keys(['Enter']);
+
+        await page.waitUntilLoaded();
+
+        await expect(page.countTokens()).resolves.toBe(4);
+        await expect(page.countTableRows()).resolves.toBe(3);
       })
     );
 


### PR DESCRIPTION
*Issue #, if available:* CR-116347209

*Description of changes:*

Add new doesNotStartsWith operator in all property filters that use text comparison operators.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
