### PR TITLE
chore: Use full npm command names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,5 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm it
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
*Description of changes:*

Addressing this comment: https://github.com/cloudscape-design/actions/pull/27#discussion_r1530742154

Make it easier to find all `npm install` instances




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
