### PR TITLE
chore: Add wait for prompt input before running chat tests

### DIFF
--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -10,6 +10,7 @@ const setupTest = (testFn: { (page: Page): Promise<void> }) => {
     await browser.url('/chat.html');
     const page = new Page(browser);
     await expect(page.countChatBubbles()).resolves.toBe(initialMessageCount);
+    await page.waitForChat();
     await testFn(page);
   });
 };

--- a/test/e2e/page/chat-page-object.ts
+++ b/test/e2e/page/chat-page-object.ts
@@ -14,6 +14,10 @@ export default class ChatPageObject extends BaseExamplePage {
     return this.getElementsCount(chatBubblesWrapper.toSelector());
   }
 
+  async waitForChat() {
+    await this.waitForVisible(promptInputWrapper.findNativeTextarea().toSelector());
+  }
+
   async sendPrompt(prompt: string) {
     const textareaSelector = promptInputWrapper.findNativeTextarea().toSelector();
     await this.setValue(textareaSelector, prompt);


### PR DESCRIPTION
This attempts to fix dry-run flakiness in e2e chat tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
