### PR TITLE
chore: Experiment with running chat tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack": "NODE_ENV=production webpack",
     "clean": "node ./scripts/clean",
     "generate-html-files": "node ./scripts/generate-html-files",
-    "jest": "node --experimental-vm-modules ./node_modules/.bin/jest ./test/**/*.test.ts",
+    "jest": "node --experimental-vm-modules ./node_modules/.bin/jest ./test/e2e/chat.test.ts",
     "build": "npm-run-all -s generate-html-files webpack",
     "pretest": "npm-run-all -s clean lint typecheck build",
     "typecheck": "tsc",

--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -9,6 +9,7 @@ const setupTest = (testFn: { (page: Page): Promise<void> }) => {
   return useBrowser(async browser => {
     await browser.url('/chat.html');
     const page = new Page(browser);
+    await page.setWindowSize({ width: 800, height: 300 });
     await expect(page.countChatBubbles()).resolves.toBe(initialMessageCount);
     await testFn(page);
   });
@@ -16,7 +17,7 @@ const setupTest = (testFn: { (page: Page): Promise<void> }) => {
 
 // These tests are consistently failing in the dry-run.
 // Disabled to unblock other PRs.
-describe.skip('Chat behavior', () => {
+describe('Chat behavior', () => {
   test(
     'Unknown prompt gets the correct response',
     setupTest(async page => {


### PR DESCRIPTION
Trying to reproduce the failed dry-run: https://github.com/cloudscape-design/components/actions/runs/12465618845/job/34791908091

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
