### PR TITLE
fix: Chat test dry run - Add VR class to the html

### DIFF
--- a/scripts/generate-html-files.js
+++ b/scripts/generate-html-files.js
@@ -42,7 +42,7 @@ function createHtml({ title, headImports, bodyImports, bodyContent }) {
     <link href="vendor.css" rel="stylesheet">
     ${headImports}
   </head>
-  <body id="b">
+  <body id="b" class="awsui-visual-refresh">
     ${bodyContent}
     <script src="libs/fake-server.js"></script>
     <script src="vendor.js"></script>

--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -14,7 +14,7 @@ const setupTest = (testFn: { (page: Page): Promise<void> }) => {
   });
 };
 
-describe.skip('Chat behavior', () => {
+describe('Chat behavior', () => {
   test(
     'Unknown prompt gets the correct response',
     setupTest(async page => {


### PR DESCRIPTION
*Issue #, if available:* AWSUI-60272

*Description of changes:* The chat test in dry run was failing because classic components were being used, adding the VR classname so the tests run with VR components instead. The test is now passing in [this PR](https://github.com/cloudscape-design/components/pull/3156).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
