### PR TITLE
chore: Export demo updates for default saved filter sets

### DIFF
--- a/src/pages/table-saved-filters/filter-set-modals.tsx
+++ b/src/pages/table-saved-filters/filter-set-modals.tsx
@@ -5,6 +5,7 @@ import React, { useRef, useState } from 'react';
 import Alert from '@cloudscape-design/components/alert';
 import Box from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
+import Checkbox from '@cloudscape-design/components/checkbox';
 import FormField from '@cloudscape-design/components/form-field';
 import Input, { InputProps } from '@cloudscape-design/components/input';
 import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
@@ -62,11 +63,12 @@ export function SaveFilterSetModal({
   query: PropertyFilterProps.Query;
   filteringProperties?: readonly PropertyFilterProps.FilteringProperty[];
   onCancel: () => void;
-  onSubmit: (formData: { name: string; description?: string }) => void;
+  onSubmit: (formData: { name: string; description?: string; isDefault?: boolean }) => void;
 }) {
   const [visible, setVisible] = useState(true);
   const [nameValue, setNameValue] = useState('');
   const [descriptionValue, setDescriptionValue] = useState('');
+  const [isDefaultFilterSet, setIsDefaultFilterSet] = useState(false);
   const [nameError, setNameError] = useState<string>();
   const nameInputRef = useRef<InputProps.Ref>(null);
 
@@ -87,6 +89,7 @@ export function SaveFilterSetModal({
     onSubmit({
       name: nameValue,
       description: descriptionValue,
+      isDefault: isDefaultFilterSet,
     });
   };
 
@@ -135,6 +138,11 @@ export function SaveFilterSetModal({
           }
         >
           <Input value={descriptionValue} onChange={({ detail }) => setDescriptionValue(detail.value)} />
+        </FormField>
+        <FormField label={<span>Default filter set</span>}>
+          <Checkbox checked={isDefaultFilterSet} onChange={({ detail }) => setIsDefaultFilterSet(detail.checked)}>
+            Set as default
+          </Checkbox>
         </FormField>
         <div>
           <Box variant="awsui-key-label">Filter values</Box>
@@ -217,6 +225,10 @@ export function UpdateFilterSetModal({
               label: 'New filter values',
               value: queryToString(newQuery, filteringProperties),
             },
+            {
+              label: 'Default filter set',
+              value: filterSet.default ? 'Yes' : 'No',
+            },
           ]}
         />
       </SpaceBetween>
@@ -289,6 +301,10 @@ export function DeleteFilterSetModal({
             {
               label: 'Filter values',
               value: queryToString(filterSet.query, filteringProperties),
+            },
+            {
+              label: 'Default filter set',
+              value: filterSet.default ? 'Yes' : 'No',
             },
           ]}
         />

--- a/test/e2e/common/table/table-preferences-tests.ts
+++ b/test/e2e/common/table/table-preferences-tests.ts
@@ -3,9 +3,12 @@
 import TablePropertyFilteringPageObject from '../../page/table-property-filtering-page-object';
 import TablePageObject from '../../page/table-page-object';
 
-export default function commonPreferencesTests(setupTest: {
-  (testFn: { (page: TablePageObject | TablePropertyFilteringPageObject): Promise<void> }): any;
-}) {
+export default function commonPreferencesTests(
+  setupTest: {
+    (testFn: { (page: TablePageObject | TablePropertyFilteringPageObject): Promise<void> }): any;
+  },
+  totalItemCount: number = 150,
+) {
   describe('Preferences', () => {
     test(
       'has 10 rows when setting page size to 10',
@@ -25,7 +28,7 @@ export default function commonPreferencesTests(setupTest: {
         await page.setTablePreferencesPageSize(3);
         await page.confirmTablePreferenceChanges();
 
-        expect(await page.countTableRows()).toBe(50);
+        expect(await page.countTableRows()).toBe(totalItemCount < 50 ? totalItemCount : 50);
       }),
     );
 

--- a/test/e2e/common/table/table-property-filtering-tests.ts
+++ b/test/e2e/common/table/table-property-filtering-tests.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT-0
 import TablePropertyFilteringPageObject from '../../page/table-property-filtering-page-object';
 
-export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject): Promise<void> }): any }) => {
+export default (
+  setupTest: { (testFn: { (page: TablePropertyFilteringPageObject): Promise<void> }): any },
+  initialAppliedFilterCount = 0,
+  filtersTableRowCounts = [11, 7, 3, 30],
+) => {
   describe('Property Filtering - Common', () => {
     test(
       'Shows the dropdown when focused',
@@ -76,7 +80,7 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
         await page.search('bbb');
         await page.keys(['Enter']);
         await expect(page.getFilterText()).resolves.toBe('');
-        await expect(page.countTokens()).resolves.toBe(1);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 1);
       }),
     );
 
@@ -103,8 +107,10 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
         await page.selectOption(1);
 
         await expect(page.isTokensVisible()).resolves.toBe(true);
-        await expect(page.getTokenText()).resolves.toBe('Domain name = abcdef01234567890.cloudfront.net');
-        await expect(page.countTokens()).resolves.toBe(1);
+
+        const tokensText = await page.getElementsText(page.findPropertyFiltering().findTokens().toSelector());
+        expect(tokensText[initialAppliedFilterCount]).toMatch(/Domain name = abcdef01234567890.cloudfront.net/);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 1);
       }),
     );
 
@@ -117,7 +123,7 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
         await page.search('021345abcdef6789.cloudfront.net');
         await page.selectOption(1);
 
-        await expect(page.countTokens()).resolves.toBe(2);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 2);
       }),
     );
 
@@ -132,8 +138,8 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(2);
-        await expect(page.countTableRows()).resolves.toBe(11);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 2);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[0]);
 
         await page.focusFilter();
         await page.selectOption(1);
@@ -144,8 +150,8 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(3);
-        await expect(page.countTableRows()).resolves.toBe(7);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 3);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[1]);
 
         await page.focusFilter();
         await page.selectOption(1);
@@ -156,8 +162,8 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(4);
-        await expect(page.countTableRows()).resolves.toBe(3);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 4);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[2]);
       }),
     );
 
@@ -172,14 +178,14 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(2);
-        await expect(page.countTableRows()).resolves.toBe(11);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 2);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[0]);
 
         await page.removeToken(1);
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(1);
-        await expect(page.countTableRows()).resolves.toBe(30);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 1);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[3]);
       }),
     );
 
@@ -194,8 +200,8 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(2);
-        await expect(page.countTableRows()).resolves.toBe(11);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 2);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[0]);
 
         await page.removeAllTokens();
         await page.waitUntilLoaded();
@@ -216,15 +222,15 @@ export default (setupTest: { (testFn: { (page: TablePropertyFilteringPageObject)
 
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(2);
-        await expect(page.countTableRows()).resolves.toBe(11);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 2);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[0]);
 
         // reload the page
         await page.reload();
         await page.waitUntilLoaded();
 
-        await expect(page.countTokens()).resolves.toBe(2);
-        await expect(page.countTableRows()).resolves.toBe(11);
+        await expect(page.countTokens()).resolves.toBe(initialAppliedFilterCount + 2);
+        await expect(page.countTableRows()).resolves.toBe(filtersTableRowCounts[0]);
       }),
     );
   });


### PR DESCRIPTION
Exports `CR-192809119`

*Description of changes:*
Added default filter set functions to the existing saved filter set demo.

This includes:
- A checkbox action in the filter actions to toggle the default (with disabled reasons)
    - Disabled reasons are for when a filter set is not selected or there are unsaved changes on the current one
- A checkbox added to the create modal
- Default state displayed in update and delete modals
- Default text disaplyed in the saved filter sets select component (labelTag)
- Applying the default filter set on page load

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
