### PR TITLE
chore: Export demo updates for type and aria fixes in split panel demo

### DIFF
--- a/src/pages/split-panel-comparison/table-config.tsx
+++ b/src/pages/split-panel-comparison/table-config.tsx
@@ -93,9 +93,10 @@ export const COLUMN_DEFINITIONS_PANEL_CONTENT_SINGLE: TableProps.ColumnDefinitio
   },
 ];
 
-export const SELECTION_LABELS = {
+export const SELECTION_LABELS: TableProps.AriaLabels<EC2Instance> = {
   ...baseTableAriaLabels,
   selectionGroupLabel: 'Instance selection',
+  itemSelectionLabel: (selectionState, row) => `Select ${row.id}`,
 };
 
 export const DEFAULT_PREFERENCES: CollectionPreferencesProps.Preferences = {

--- a/src/pages/split-panel-comparison/utils.tsx
+++ b/src/pages/split-panel-comparison/utils.tsx
@@ -13,7 +13,7 @@ import { TableProps } from '@cloudscape-design/components/table';
 
 import { isVisualRefresh } from '../../common/apply-mode';
 import { EC2Instance } from '../../resources/types';
-import { COLUMN_DEFINITIONS_PANEL_CONTENT_SINGLE, SELECTION_LABELS } from './table-config';
+import { COLUMN_DEFINITIONS_PANEL_CONTENT_SINGLE } from './table-config';
 
 const EMPTY_PANEL_CONTENT = {
   header: '0 instances selected',
@@ -143,6 +143,7 @@ export const getPanelContentComparison = (items: Readonly<EC2Instance[]>) => {
   interface TransformedData extends Record<string, string | number | string[]> {
     comparisonType: string;
   }
+
   const transformedData: TransformedData[] = properties.map(key => {
     const data: TransformedData = { comparisonType: keyHeaderMap[key] };
 
@@ -179,7 +180,6 @@ export const getPanelContentComparison = (items: Readonly<EC2Instance[]>) => {
       <Box padding={{ bottom: 'l' }}>
         <Table
           enableKeyboardNavigation={true}
-          ariaLabels={SELECTION_LABELS}
           header={<Header variant="h2">Compare details</Header>}
           items={transformedData}
           columnDefinitions={columnDefinitions}


### PR DESCRIPTION
Export demo updates for type and aria fixes in split panel demo. This fixes the failed demo test for https://github.com/cloudscape-design/components/pull/3492.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
