### PR TITLE
chore: Update supported Safari versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "last 3 Chrome major versions",
     "last 3 Firefox major versions",
     "last 3 Edge major versions",
-    "last 3 Safari major versions"
+    "last 3 Safari versions"
   ],
   "lint-staged": {
     "*.html": [


### PR DESCRIPTION
Until recently, we supported the latest three major versions of Safari.
This has changed. We do now support the latest three minor versions of Safari for macOS. This aligns with https://repost.aws/knowledge-center/browsers-management-console

Related links, issue #, if available: `AWSUI-60833`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
