### PR TITLE
fix: Disable table sorting during inline edit

### DIFF
--- a/src/pages/table-editable/root.tsx
+++ b/src/pages/table-editable/root.tsx
@@ -133,8 +133,7 @@ function TableContent({ loadHelpPanelContent, distributions }: TableContentProps
     const newItem: Distribution = { ...currentItem, [column.id]: value };
 
     if (collectionProps.sortingColumn === column) {
-      // This call signature is not supported by the function; not sure what to do with this
-      // actions.setSorting(null);
+      actions.setSorting({ sortingColumn: {} });
       fullCollection = [...allPageItems];
     }
 
@@ -157,6 +156,7 @@ function TableContent({ loadHelpPanelContent, distributions }: TableContentProps
       columnDefinitions={columnDefinitions}
       columnDisplay={preferences?.contentDisplay}
       items={itemsSnap || items}
+      trackBy="id"
       submitEdit={handleSubmit}
       ariaLabels={distributionEditableTableAriaLabels}
       renderAriaLive={renderAriaLive}


### PR DESCRIPTION
Fixes https://github.com/cloudscape-design/components/issues/4690

Before the changes, the bug is manually reproducible by following these steps:
1. Enable sorting on on of the columns
2. Edit the value of that column for an item, so that it would change its position if reapplying sorting. At this point it will still not change its position (expected)
3. Edit it again. Now the sorting will be reapplied (unexpected)

Related: `CR-288926708`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
