### PR TITLE
chore: Bump js-yaml to 3.15.0 and 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3194,9 +3194,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15819,9 +15819,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Bumps [js-yaml](https://github.com/nodeca/js-yaml) to patched versions to address a quadratic-complexity DoS in YAML merge-key handling.

This is a **lockfile-only** change (transitive dependency; `package-lock.json` only). Two independent major-version lines are present in the tree and both are bumped:

| Instance | From | To | Advisories |
|---|---|---|---|
| `js-yaml` (4.x) | 4.2.0 | 4.3.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (High) |
| `@istanbuljs/load-nyc-config` → `js-yaml` (3.x) | 3.14.2 | 3.15.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (High), [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) (Medium) |

- **Patched versions:** `3.15.0` (v3 line) and `4.3.0` (v4 line)

Lockfile regenerated with the repo's `scripts/clean-package-lock.js` post-processing so only the `js-yaml` entries change.

> Opened by roko-dependabot-handler on behalf of @ernst-dev to remediate Dependabot alerts that had no auto-generated fix.