### PR TITLE
chore: Remediate 7 Dependabot security alerts (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6560,9 +6560,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11914,9 +11914,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -12612,9 +12612,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13159,9 +13159,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19013,9 +19013,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21571,9 +21571,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Automated Dependabot security-alert remediation

Alert-driven remediation of this repository's **open** Dependabot security alerts.
Baseline: `d40bfcc0e` on `main`.

### Alerts resolved (7 of 7)

| Alert | Sev | Package | Major line | Vulnerable range | First patched | Now resolved to | Advisory |
|---|---|---|---|---|---|---|---|
| #218 | high | `fast-uri` | 3.x | `>= 3.0.0, < 3.1.5` | 3.1.5 | `3.1.5` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (CVE-2026-18446) |
| #213 | medium | `ip-address` | 10.x | `>= 10.1.1, <= 10.2.0` | 10.2.1 | `10.4.0` | [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) (CVE-2026-54272) |
| #214 | medium | `ip-address` | 10.x | `>= 10.1.1, <= 10.2.1` | 10.2.2 | `10.4.0` | [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh) (CVE-2026-69198) |
| #215 | high | `ip-address` | 10.x | `<= 10.3.0` | 10.3.1 | `10.4.0` | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) (CVE-2026-69192) |
| #216 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `6.28.0` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) (CVE-2026-16728) |
| #217 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `6.28.0` | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (CVE-2026-15157) |
| #219 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `6.28.0` | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (CVE-2026-16729) |

### How this was remediated

* **Rung 1 — `npm audit fix --package-lock-only --ignore-scripts`** (no `--force` was used anywhere in this run).
* The repo's own `prepare-package-lock` convention (`postinstall` in `@cloudscape-design/build-tools`) was applied afterwards, so no `@cloudscape-design/*` entries are (re-)introduced into the lockfile.
* npm's full reconciliation additionally healed unrelated pre-existing lockfile drift (stale entries, `dev`/`optional` flags, unrelated minor bumps). **That collateral was deliberately discarded**: only the security-relevant entries from npm's computed result were applied on top of the committed lockfile, so this diff contains alert-driven changes only.
* Verified with `npm ls --package-lock-only --all`: **zero new** unmet/invalid dependency problems versus `main`.

### Lockfile changes (6)

| Package | From | To | Scope | Lockfile path |
|---|---|---|---|---|
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion` |
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/glob/node_modules/brace-expansion` |
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/readdir-glob/node_modules/brace-expansion` |
| `fast-uri` | 3.1.4 | 3.1.5 | dev | `node_modules/fast-uri` |
| `ip-address` | 10.2.0 | 10.4.0 | dev | `node_modules/ip-address` |
| `undici` | 6.27.0 | 6.28.0 | dev | `node_modules/undici` |

### NPMPM (NpmPrettyMuch) availability — internal build safety

**Not applicable — 0 non-dev dependencies changed.** Every version bump in this PR is `dev: true`, which the NPMPM availability check skips, so there is no internal-build (Brazil) impact and the check should come back green.

### Does merging clear this repository's alert list?

**Yes.** Merging this PR is expected to close **all 7** of this repository's currently-open Dependabot security alerts.

---

<sub>Existing Dependabot-authored PRs were deliberately **not** touched, reviewed, rebased, or closed by this run.</sub>

> Opened by roko-dependabot on behalf of @ernst-dev. Alert-driven remediation; not merged — a human must review and merge.
